### PR TITLE
Send “add” uevent when adding a device.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 0.5.2 (UNRELEASED)
 ------------------
 - Also send DEVNAME in uevent when available. Thanks Chris Halse Rogers!
+- Send an "add" uevent when adding a device
 
 0.5.1 (2014-01-16)
 ------------------

--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -411,6 +411,8 @@ public class Testbed: GLib.Object {
         if (attributes.length % 2 != 0)
             warning("add_devicev: Ignoring attribute key '%s' without value", attributes[attributes.length-1]);
 
+        uevent(dev_path, "add");
+
         return dev_path;
     }
 


### PR DESCRIPTION
There doesn't seem to be any reason not to do this, and it's reasonable to
expect that adding a udev device will cause an ‘add’ uevent
