### PR TITLE
Call open(.., .., mode) when O_TMPFILE is specified.

### DIFF
--- a/src/libumockdev-preload.c
+++ b/src/libumockdev-preload.c
@@ -1082,7 +1082,7 @@ int prefix ## open ## suffix (const char *path, int flags, ...)	    \
 	return -1;						    \
     }								    \
     DBG(DBG_PATH, "testbed wrapped " #prefix "open" #suffix "(%s) -> %s\n", path, p); \
-    if (flags & O_CREAT) {					    \
+    if (flags & (O_CREAT | O_TMPFILE)) {			    \
 	mode_t mode;						    \
 	va_list ap;						    \
 	va_start(ap, flags);				    	    \


### PR DESCRIPTION
When creating a temporary file with 'open' (using the 'O_TMPFILE' flag), 'mode' argument must be specified (see explanation for 'O_CREAT' at http://man7.org/linux/man-pages/man2/open.2.html). The path in 'open' could be one that is trapped by umockdev, e.g. "/dev/shm". In this case, 'umockdev' fails to call the version of 'open' with 'mode' since it expects the 'O_CREAT' flag, which, in this case, doesn't exist. This commit allows correct pass-through of 'open' by 'umockdev'.
