### PR TITLE
include sys/sysmacros.h for major/minor/makedev

### DIFF
--- a/src/libumockdev-preload.c
+++ b/src/libumockdev-preload.c
@@ -39,6 +39,7 @@
 #include <inttypes.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/inotify.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>

--- a/src/posix_extra.vapi
+++ b/src/posix_extra.vapi
@@ -2,9 +2,9 @@
 namespace Posix {
 #if !VALA_0_20
     // https://bugzilla.gnome.org/show_bug.cgi?id=693411
-    [CCode (cheader_filename = "sys/types.h")]
+    [CCode (cheader_filename = "sys/sysmacros.h")]
     uint major (dev_t dev);
-    [CCode (cheader_filename = "sys/types.h")]
+    [CCode (cheader_filename = "sys/sysmacros.h")]
     uint minor (dev_t dev);
 #endif
 

--- a/tests/test-umockdev.c
+++ b/tests/test-umockdev.c
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/sysmacros.h>
 #include <sys/un.h>
 #include <linux/usbdevice_fs.h>
 #include <linux/input.h>


### PR DESCRIPTION
These funcs are defined in the sys/sysmacros.h header, not sys/types.h.
Linux C libraries are updating to drop the implicit include, so we need
to include it explicitly.