### PR TITLE
Don't declare constants as static

### DIFF
--- a/src/umockdev-record.vala
+++ b/src/umockdev-record.vala
@@ -349,7 +349,7 @@ static string[] opt_script;
 static string[] opt_evemu_events;
 static bool opt_version = false;
 
-static const GLib.OptionEntry[] options = {
+const GLib.OptionEntry[] options = {
     {"all", 'a', 0, OptionArg.NONE, ref opt_all, "Record all devices"},
     {"ioctl", 'i', 0, OptionArg.FILENAME, ref opt_ioctl,
      "Trace ioctls on the device, record into given file. In this case, all positional arguments are a command (and its arguments) to run that gets traced.", "devname=FILE"},

--- a/src/umockdev-run.vala
+++ b/src/umockdev-run.vala
@@ -32,7 +32,7 @@ static string[] opt_evemu_events;
 static string[] opt_program;
 static bool opt_version = false;
 
-static const GLib.OptionEntry[] options = {
+const GLib.OptionEntry[] options = {
     {"device", 'd', 0, OptionArg.FILENAME_ARRAY, ref opt_device,
      "Load an umockdev-record device description into the testbed. Can be specified multiple times.",
      "filename"},


### PR DESCRIPTION
Fixes:

    src/umockdev-run.vala:35.1-54.2: warning: the modifier `static' is not applicable to constants
    src/umockdev-record.vala:352.1-363.2: warning: the modifier `static' is not applicable to constants