### PR TITLE
Refine detection of being in mock environment

### DIFF
--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -18,6 +18,9 @@
 
 namespace UMockdev {
 
+private bool __in_mock_env_initialized = false;
+private bool __in_mock_env_result = false;
+
 /**
  * SECTION:umockdev
  * @title: umockdev
@@ -1721,10 +1724,15 @@ private class SocketServer {
  */
 public bool in_mock_environment()
 {
-    string? preload = Environment.get_variable ("LD_PRELOAD");
-    if (preload == null)
-        return false;
-    return preload.contains ("libumockdev-preload");
+
+    if (!__in_mock_env_initialized) {
+        Posix.Stat st;
+        if (Posix.stat("/sys", out st) >= 0)
+            __in_mock_env_result = st.st_ino > 1 && st.st_size > 0;
+        __in_mock_env_initialized = true;
+    }
+
+    return __in_mock_env_result;
 }
 
 /**


### PR DESCRIPTION
umockdev-run itself sets $LD_PRELOAD, so this does not avoid the error
message about nonexisting devices in uevent_sender_send(). Instead,
check if /sys looks like a real file system directory, i. e. it is a
mock, not the real sysfs.