### PR TITLE
thunderbolt: Create symlinks the same way like usb and pci

### DIFF
--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -405,7 +405,7 @@ public class Testbed: GLib.Object {
         /* create device and corresponding subsystem dir */
         if (DirUtils.create_with_parents(dev_dir, 0755) != 0)
             error("cannot create dev dir '%s': %s", dev_dir, strerror(errno));
-        if (subsystem != "usb" && subsystem != "pci") {
+        if (subsystem != "usb" && subsystem != "pci" && subsystem != "thunderbolt") {
             /* class/ symlinks */
             var class_dir = Path.build_filename(this.sys_dir, "class", subsystem);
             if (DirUtils.create_with_parents(class_dir, 0755) != 0)


### PR DESCRIPTION
This should create /sys/bus/thunderbolt and links.