### PR TITLE
thunderbolt: Remove symlinks

### DIFF
--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -594,7 +594,7 @@ public class Testbed: GLib.Object {
         FileUtils.unlink(Path.build_filename(this.sys_dir, "class", subsystem, devname));
         DirUtils.remove(Path.build_filename(this.sys_dir, "class", subsystem));
         // bus symlink
-        if (subsystem == "usb" || subsystem == "pci") {
+        if (subsystem == "usb" || subsystem == "pci" || subsystem == "thunderbolt") {
             FileUtils.unlink(Path.build_filename(this.sys_dir, "bus", subsystem, "devices", devname));
             DirUtils.remove(Path.build_filename(this.sys_dir, "bus", subsystem, "devices"));
             DirUtils.remove(Path.build_filename(this.sys_dir, "bus", subsystem));


### PR DESCRIPTION
Fixes symlinks not removed during remove_device()

Sorry missed this part in the previous patch.