### PR TITLE
Fix architecture specific /proc test

### DIFF
--- a/tests/test-umockdev.c
+++ b/tests/test-umockdev.c
@@ -2013,9 +2013,9 @@ t_testbed_proc(UMockdevTestbedFixture * fixture, gconstpointer data)
     gboolean found;
 
     /* should be the real file */
-    g_assert(g_file_get_contents("/proc/cpuinfo", &contents, NULL, NULL));
-    if (!strstr(contents, "processor")) {
-        g_printerr("'processor' not found in /proc/cpuinfo: ----------\n%s\n----------", contents);
+    g_assert(g_file_get_contents("/proc/meminfo", &contents, NULL, NULL));
+    if (!strstr(contents, "MemTotal:")) {
+        g_printerr("'MemTotal:' not found in /proc/meminfo: ----------\n%s\n----------", contents);
         g_test_fail();
     }
     g_free(contents);


### PR DESCRIPTION
`/proc/cpuinfo` is very architecture specific and has no reliable
strings in it. Use `/proc/meminfo` instead.

Thanks to John Paul Adrian Glaubitz!

Fixes #73