### PR TITLE
Support CentOS 7 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 - TEST=tests/run-ubuntu-chroot RELEASE=bionic ARCH=i386
 - TEST=tests/run-ubuntu-chroot RELEASE=xenial
 - TEST=tests/run-alpine-docker RELEASE=latest
+- TEST=tests/run-centos-docker RELEASE=7
 script: $TEST
 cache:
   directories:

--- a/tests/run-centos-docker
+++ b/tests/run-centos-docker
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+# keep container around if $DEBUG is set, and allow strace
+RM=""
+[ -n "${DEBUG:-}" ] && OPTS="--privileged" || OPTS="--rm"
+
+sudo docker run --interactive $OPTS --volume `pwd`:/source centos:${RELEASE:-latest} /bin/sh << EOF
+
+# install build dependencies
+yum -y install autoconf automake gcc glib2-devel gtk-doc libgudev1-devel libtool libudev-devel make python-gobject vala
+
+# run build as user
+useradd guest
+su -s /bin/sh - guest << EOG
+set -ex
+cp -r /source /tmp
+cd /tmp/source
+./autogen.sh
+make -j4
+make check
+EOG
+
+EOF

--- a/tests/test-umockdev.py
+++ b/tests/test-umockdev.py
@@ -190,12 +190,17 @@ A: simple_attr=1
             self.assertEqual(f.read(), b'\x41\xFF\x00\x05\xFF\x00')
 
     def test_add_from_string_errors(self):
+        if sys.version_info[0] == 2 or (sys.version_info[0] == 3 and sys.version_info[1] < 2):
+            assertRaisesRegex = self.assertRaisesRegexp
+        else:
+            assertRaisesRegex = self.assertRaisesRegex
+
         # does not start with P:
-        with self.assertRaisesRegex(GLib.GError, 'must start with.*P:') as cm:
+        with assertRaisesRegex(GLib.GError, 'must start with.*P:') as cm:
             self.testbed.add_from_string ('E: SIMPLE_PROP=1\n')
 
         # no value
-        with self.assertRaisesRegex(GLib.GError, 'malformed attribute') as cm:
+        with assertRaisesRegex(GLib.GError, 'malformed attribute') as cm:
             self.testbed.add_from_string ('P: /devices/dev1\nE: SIMPLE_PROP\n')
 
 unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
I played around a little with Docker in Travis and here are the results. First of all - this is going to fail until #85 is merged, then I'll rebase this branch. I'm submitting this PR beforehand, as I'd like to discuss one issue I come across during the testing.

The test suite appears to be passing during the build in Fedora Copr, as I forgot to add the `python-gobject` package to the dependencies. Thus, the `make check` just skips all the test using the Python GI:

```
== Running GI test with python against build tree ==
GI module not available, skipping test: No module named gi
```

After I installed the missing package, the `make check` started failing:
```
======================================================================
ERROR: test_add_from_string_errors (__main__.Testbed)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./tests/test-umockdev.py", line 194, in test_add_from_string_errors
    with self.assertRaisesRegex(GLib.GError, 'must start with.*P:') as cm:
AttributeError: 'Testbed' object has no attribute 'assertRaisesRegex'
```

According to the [Python 3 documentation](https://docs.python.org/3.3/library/unittest.html#unittest.TestCase.assertRaisesRegex) the `assertRaisesRegex` method used to be called `assertRaisesRegexp` before Python 3.2. CentOS doesn't have Python 3 installed by default, which results in the aforementioned fail.

I think there are two possible solutions - either to install Python 3 from the EPEL or to slightly modifiy the test suite. I decided to do the latter, which can be found in the commit e65e99f. Of course, that's just my idea - if the Python 3 installation would be a better choice, I can drop the offending commit.

For testing purposes I merged patches from this PR with the patch from the #85 to see if everything works as expected - and it does, see https://travis-ci.org/mrc0mmand/umockdev/builds/431913447