### PR TITLE
Don't expect size to be non-zero for mocked /sys

### DIFF
--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -1740,7 +1740,7 @@ public bool in_mock_environment()
     if (!__in_mock_env_initialized) {
         Posix.Stat st;
         if (Posix.stat("/sys", out st) >= 0)
-            __in_mock_env_result = st.st_ino > 1 && st.st_size > 0;
+            __in_mock_env_result = st.st_ino > 1;
         __in_mock_env_initialized = true;
     }
 


### PR DESCRIPTION
This isn't true for tmpfs, which leads to hard to debug errors.