### PR TITLE
Don't display grep 'binary file matches' errors

### DIFF
--- a/tests/test-static-code
+++ b/tests/test-static-code
@@ -7,7 +7,7 @@ ROOTDIR=$(dirname $(readlink -f $0))/..
 CODE_INT=`grep -B 100000 'Overridden libc' $ROOTDIR/src/libumockdev-preload.c`
 CODE_WRAPPERS=`grep -A 100000 'Overridden libc' $ROOTDIR/src/libumockdev-preload.c`
 
-LIBC_OVERRIDES=`echo "$CODE_WRAPPERS" | grep '^[a-z_]\+(' | grep -v '^WRAP_' | cut -f1 -d'('`
+LIBC_OVERRIDES=`echo "$CODE_WRAPPERS" | grep --text '^[a-z_]\+(' | grep -v '^WRAP_' | cut -f1 -d'('`
 
 RET=0
 
@@ -27,7 +27,7 @@ R=$(echo "$CODE_INT" | grep --text -B1  '^[a-z_]\+(' | awk 'BEGIN { RS="--\n" } 
 check_empty "$R" "preload internal code part has exported function(s)"
 
 # wrappers must be exported
-R=$(echo "$CODE_WRAPPERS" | grep -B1  '^[a-z_]\+(' | awk 'BEGIN { RS="--\n" } /static/ { print $0 }')
+R=$(echo "$CODE_WRAPPERS" | grep --text -B1  '^[a-z_]\+(' | awk 'BEGIN { RS="--\n" } /static/ { print $0 }')
 check_empty "$R" "preload libc wrapped code part has non-exported function(s)"
 
 # wrappers must not have a '_' in the name, libc doesn't use that style


### PR DESCRIPTION
Those warnings a printed on stderr since the new grep 3.5 version,
which fails the Debian autopkgtest

From the grep NEWS
```
 Noteworthy changes in release 3.5 (2020-09-27) [stable]

** Changes in behavior

  The message that a binary file matches is now sent to standard error
  and the message has been reworded from "Binary file FOO matches" to
  "grep: FOO: binary file matches", to avoid confusion with ordinary
  output or when file names contain spaces and the like, and to be
  more consistent with other diagnostics.  For example, commands
  like 'grep PATTERN FILE | wc' no longer add 1 to the count of
  matching text lines due to the presence of the message.  Like other
  stderr messages, the message is now omitted if the --no-messages
  (-s) option is given.
```