### PR TITLE
record: Do not filter out firmware_node

### DIFF
--- a/src/umockdev-record.vala
+++ b/src/umockdev-record.vala
@@ -186,7 +186,7 @@ print_device_attributes(string devpath, string subdir)
     string entry;
     // filter out the uninteresting attributes, sort the others
     while ((entry = d.read_name()) != null)
-        if (entry != "subsystem" && entry != "firmware_node" && entry != "uevent")
+        if (entry != "subsystem" && entry != "uevent")
             attributes.append(entry);
         else {
             // don't look into subdirs which are devices by themselves


### PR DESCRIPTION
I am trying to create some tests for thermald, and it is accessing the
firmware_node. As such, it is helpful to store the information in the
recording.