### PR TITLE
Fix strncmp off-by-one in libumockdev-preload.c

### DIFF
--- a/src/libumockdev-preload.c
+++ b/src/libumockdev-preload.c
@@ -154,7 +154,7 @@ trap_path(const char *path)
     if (prefix == NULL)
 	return path;
 
-    if (strncmp(path, "/dev/", 5) == 0 || strcmp(path, "/dev") == 0 || strncmp(path, "/proc/", 5) == 0)
+    if (strncmp(path, "/dev/", 5) == 0 || strcmp(path, "/dev") == 0 || strncmp(path, "/proc/", 6) == 0)
 	check_exist = 1;
     else if (strncmp(path, "/sys/", 5) != 0 && strcmp(path, "/sys") != 0)
 	return path;


### PR DESCRIPTION
The `"/proc/"` string is of len 6 instead of 5.

This was found with a "cstrnfinder" research and I haven't tested this change (more info https://twitter.com/disconnect3d_pl/status/1339757359896408065). Close this PR if this change is incorrect.