### PR TITLE
umockdev: Only start socket server thread after creating FDs

### DIFF
--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -1760,7 +1760,6 @@ private class SocketServer {
         this.running = true;
         this.socket_scriptfile = new HashTable<string, string> (str_hash, str_equal);
         this.script_runners = new HashTable<string, ScriptRunner> (str_hash, str_equal);
-        this.thread = new Thread<void*> ("SocketServer", this.run);
 
         // we use a control pipe which we trigger when adding or stopping, to
         // interrupt the select()
@@ -1768,6 +1767,8 @@ private class SocketServer {
         assert (Posix.pipe (fds) == 0);
         this.ctrl_r = fds[0];
         this.ctrl_w = fds[1];
+
+        this.thread = new Thread<void*> ("SocketServer", this.run);
     }
 
     ~SocketServer ()


### PR DESCRIPTION
Otherwise we may end up selecting an FD that does not exist, detecting
EOF and the thread quits immediately. This causes random failures of the
test suite.

A sample of a failure caused by this can be seen in https://github.com/martinpitt/umockdev/runs/2730392818?check_suite_focus=true#step:3:2025

FD is 0 here, but should obviously be non-zero.

EDIT: Update link; for some reason it ended up pointing to the later run.