### PR TITLE
pcap: Fix crash after reaching end of recording

### DIFF
--- a/src/libumockdev-preload.c
+++ b/src/libumockdev-preload.c
@@ -558,6 +558,8 @@ ioctl_emulate(int fd, IOCTL_REQUEST_TYPE request, void *arg)
 		errno = req.arg2;
 
 		IOCTL_UNLOCK;
+		/* Force a context switch so that other threads can take the lock */
+		usleep(0);
 		return req.arg1;
 
 	    case IOCTL_RES_RUN:

--- a/src/umockdev-pcap.vala
+++ b/src/umockdev-pcap.vala
@@ -176,6 +176,9 @@ internal class IoctlUsbPcapHandler : IoctlBase {
         if (cur_buf == null) {
             cur_buf = rec.next(ref cur_hdr);
 
+            if (cur_buf == null)
+                return null;
+
             usb_header_mmapped *urb_hdr = (void*) cur_buf;
 
             cur_waiting_since = now;

--- a/src/umockdev-pcap.vala
+++ b/src/umockdev-pcap.vala
@@ -137,6 +137,15 @@ internal class IoctlUsbPcapHandler : IoctlBase {
                     Ioctl.usbdevfs_urb *urb = (Ioctl.usbdevfs_urb*) urb_info.urb_data.data;
                     urb.status = -Posix.ENOENT;
 
+                    /* Warn if we are discarding an urb that had no matching submit
+                     * in the recording. The replay may be stuck at this point and
+                     * we are timing out on URBs that will not replay.
+                     */
+                    if (urb_info.pcap_id == 0) {
+                        message("Replay may be stuck: Reaping discard URB of type %d, for endpoint 0x%02x with length %d without corresponding submit",
+                                urb.type, urb.endpoint, urb.buffer_length);
+                    }
+
                     urb_info.urb_data.dirty(false);
                 } else {
                     urb_info = next_reapable_urb();


### PR DESCRIPTION
When the end of recording is reached, we might try to access URB
information that did not exist. Simply return immediately instead of
going on to fix this.