### PR TITLE
Public ioctl api

### DIFF
--- a/docs/reference/meson.build
+++ b/docs/reference/meson.build
@@ -6,11 +6,12 @@ version_xml = configure_file(
 # HACK: need to find valac'ed umockdev.c for gtk-doc; https://github.com/mesonbuild/meson/issues/3892
 # this isn't predictable between meson versions
 umockdev_c = run_command('sh', '-ec', 'find -name umockdev.c| xargs dirname').stdout().strip()
+umockdev_ioctl_c = run_command('sh', '-ec', 'find -name umockdev-ioctl.c| xargs dirname').stdout().strip()
 
 gnome = import('gnome')
 gnome.gtkdoc('umockdev',
   main_xml: 'umockdev-docs.xml',
-  src_dir: [meson.build_root(), umockdev_c],
+  src_dir: [meson.build_root(), umockdev_c, umockdev_ioctl_c],
   content_files: [version_xml],
   ignore_headers: ['uevent_sender.h', 'ioctl_tree.h', 'debug.h'],
   scan_args: ['--rebuild-types'],

--- a/docs/reference/umockdev-docs.xml
+++ b/docs/reference/umockdev-docs.xml
@@ -28,6 +28,7 @@
   <chapter>
     <title>API reference</title>
         <xi:include href="xml/umockdev.xml"/>
+        <xi:include href="xml/umockdev-ioctl.xml"/>
         <xi:include href="xml/functions.xml"/>
         <xi:include href="xml/umockdeverror.xml"/>
 

--- a/docs/reference/umockdev-sections.txt
+++ b/docs/reference/umockdev-sections.txt
@@ -20,7 +20,10 @@ umockdev_testbed_get_property
 umockdev_testbed_uevent
 umockdev_testbed_add_from_string
 umockdev_testbed_add_from_file
+umockdev_testbed_attach_ioctl
+umockdev_testbed_detach_ioctl
 umockdev_testbed_load_ioctl
+umockdev_testbed_load_pcap
 umockdev_testbed_load_script
 umockdev_testbed_load_socket_script
 umockdev_testbed_load_evemu_events
@@ -44,6 +47,30 @@ umockdev_testbed_get_type
 <FILE>functions</FILE>
 <TITLE>global functions</TITLE>
 umockdev_in_mock_environment
+</SECTION>
+
+<SECTION>
+<FILE>umockdev-ioctl</FILE>
+<TITLE>UMockdev Ioctl emulation</TITLE>
+UMockdevIoctlBase
+UMockdevIoctlBaseClass
+umockdev_ioctl_base_new
+
+UMockdevIoctlData
+umockdev_ioctl_data_ref
+umockdev_ioctl_data_unref
+umockdev_ioctl_data_resolve
+umockdev_ioctl_data_set_ptr
+umockdev_ioctl_data_reload
+
+UMockdevIoctlClient
+umockdev_ioctl_client_complete
+umockdev_ioctl_client_abort
+umockdev_ioctl_client_execute
+umockdev_ioctl_client_get_arg
+umockdev_ioctl_client_get_connected
+umockdev_ioctl_client_get_devnode
+umockdev_ioctl_client_get_request
 </SECTION>
 
 <SECTION>

--- a/src/libumockdev-preload.c
+++ b/src/libumockdev-preload.c
@@ -645,25 +645,25 @@ remote_emulate(int fd, int cmd, long arg1, long arg2)
 	    case IOCTL_RES_ABORT:
 		fprintf(stderr, "ERROR: libumockdev-preload: Server requested abort on device %s, exiting\n",
 			fdinfo->dev_path);
-		exit(1);
+		abort();
 
 	    default:
 		fprintf(stderr, "ERROR: libumockdev-preload: Error communicating with ioctl socket, unknown command: %ld (res: %d)\n",
 			req.cmd, res);
-		exit(1);
+		abort();
 	}
     }
 
 con_eof:
     fprintf(stderr, "ERROR: libumockdev-preload: Error communicating with ioctl socket, received EOF\n");
     pthread_sigmask(SIG_SETMASK, &sig_restore, NULL);
-    exit(1);
+    abort();
 
 con_err:
     fprintf(stderr, "ERROR: libumockdev-preload: Error communicating with ioctl socket, errno: %d\n",
 	    errno);
     pthread_sigmask(SIG_SETMASK, &sig_restore, NULL);
-    exit(1);
+    abort();
 }
 
 /********************************

--- a/src/umockdev-ioctl.vala
+++ b/src/umockdev-ioctl.vala
@@ -144,38 +144,17 @@ public class IoctlData {
      * between two separate ioctl's).
      * It is very unlikely that such an explicit reload is needed.
      *
-     * Note pointers modified cannot be reloaded. As such, you may need to
-     * resolve the data again and it is usually a good idea to do so.
-     *
-     * The function will try to recursively update any resolved pointers. If
-     * the pointer was modified by the client it will not be resolved
-     * afterwards!
+     * Doing this unresolves any resolved pointers. Take care to re-resolve
+     * them and use the newly resolved #IoctlData in case you need to access
+     * the data.
      *
      * Returns: #TRUE on success, #FALSE otherwise
      */
     public bool reload() throws IOError {
         load_data();
 
-        IoctlData[] old_children = children;
-        size_t[] old_offsets = children_offset;
-
         children.resize(0);
         children_offset.resize(0);
-
-        for (int i = 0; i < old_children.length; i++) {
-            /* If the pointer has an unexpected value, then just drop the reference. */
-            if (*((size_t*) &data[old_offsets[i]]) != old_children[i].client_addr)
-                continue;
-
-            /* Reload and set correct pointer. */
-            old_children[i].reload();
-
-            *((void**) &data[old_offsets[i]]) = old_children[i].data;
-
-            /* Store in our new children array. */
-            children += old_children[i];
-            children_offset += old_offsets[i];
-        }
 
         return true;
     }

--- a/src/umockdev-ioctl.vala
+++ b/src/umockdev-ioctl.vala
@@ -437,15 +437,6 @@ public class IoctlClient : GLib.Object {
 
         if (!handled) {
             if (args[0] == 1)
-                handled = handler.handle_ioctl(this);
-            else if (args[0] == 7)
-                handled = handler.handle_read(this);
-            else
-                handled = handler.handle_write(this);
-        }
-
-        if (!handled) {
-            if (args[0] == 1)
                 GLib.Signal.emit_by_name(handler, "handle-ioctl", this, out handled);
             else if (args[0] == 7)
                 GLib.Signal.emit_by_name(handler, "handle-read", this, out handled);
@@ -556,13 +547,21 @@ private class StartListenClosure {
     }
 }
 
+
+[ CCode(cname="G_STRUCT_OFFSET(UMockdevIoctlBaseClass, handle_ioctl)") ]
+extern const int IOCTL_BASE_HANDLE_IOCTL_OFFSET;
+[ CCode(cname="G_STRUCT_OFFSET(UMockdevIoctlBaseClass, handle_read)") ]
+extern const int IOCTL_BASE_HANDLE_READ_OFFSET;
+[ CCode(cname="G_STRUCT_OFFSET(UMockdevIoctlBaseClass, handle_write)") ]
+extern const int IOCTL_BASE_HANDLE_WRITE_OFFSET;
+
 public class IoctlBase: GLib.Object {
     private HashTable<string,Cancellable> listeners;
 
     static construct {
-        GLib.Signal.@new("handle-ioctl", typeof(IoctlBase), GLib.SignalFlags.RUN_LAST, 0, signal_accumulator_true_handled, null, null, typeof(bool), 1, typeof(IoctlClient));
-        GLib.Signal.@new("handle-read", typeof(IoctlBase), GLib.SignalFlags.RUN_LAST, 0, signal_accumulator_true_handled, null, null, typeof(bool), 1, typeof(IoctlClient));
-        GLib.Signal.@new("handle-write", typeof(IoctlBase), GLib.SignalFlags.RUN_LAST, 0, signal_accumulator_true_handled, null, null, typeof(bool), 1, typeof(IoctlClient));
+        GLib.Signal.@new("handle-ioctl", typeof(IoctlBase), GLib.SignalFlags.RUN_LAST, IOCTL_BASE_HANDLE_IOCTL_OFFSET, signal_accumulator_true_handled, null, null, typeof(bool), 1, typeof(IoctlClient));
+        GLib.Signal.@new("handle-read", typeof(IoctlBase), GLib.SignalFlags.RUN_LAST, IOCTL_BASE_HANDLE_READ_OFFSET, signal_accumulator_true_handled, null, null, typeof(bool), 1, typeof(IoctlClient));
+        GLib.Signal.@new("handle-write", typeof(IoctlBase), GLib.SignalFlags.RUN_LAST, IOCTL_BASE_HANDLE_WRITE_OFFSET, signal_accumulator_true_handled, null, null, typeof(bool), 1, typeof(IoctlClient));
     }
 
     construct {

--- a/src/umockdev-pcap.vala
+++ b/src/umockdev-pcap.vala
@@ -48,10 +48,10 @@ internal class IoctlUsbPcapHandler : IoctlBase {
     private int bus;
     private int device;
 
-    public IoctlUsbPcapHandler(MainContext? ctx, string file, int bus, int device)
+    public IoctlUsbPcapHandler(string file, int bus, int device)
     {
         char errbuf[pcap.ERRBUF_SIZE];
-        base (ctx);
+        base ();
 
         this.bus = bus;
         this.device = device;

--- a/src/umockdev-record.vala
+++ b/src/umockdev-record.vala
@@ -325,12 +325,12 @@ record_ioctl(string root_dir, string arg)
 
     /* SPI: major 153, character device */
     if (!is_block && devnum.has_prefix("153:"))
-        handler = new UMockdev.IoctlSpiRecorder(null, dev, outfile);
+        handler = new UMockdev.IoctlSpiRecorder(dev, outfile);
     else
-        handler = new UMockdev.IoctlTreeRecorder(null, dev, outfile);
+        handler = new UMockdev.IoctlTreeRecorder(dev, outfile);
 
     string sockpath = Path.build_filename(root_dir, "ioctl", dev);
-    handler.register_path(dev, sockpath);
+    handler.register_path(null, dev, sockpath);
 
     return handler;
 }

--- a/src/umockdev-spi.vala
+++ b/src/umockdev-spi.vala
@@ -71,10 +71,6 @@ private struct TransferChunk {
 
 internal abstract class IoctlSpiBase : IoctlBase {
 
-    IoctlSpiBase(MainContext? ctx) {
-        base(ctx);
-    }
-
     internal long iter_ioctl_vector(ulong count, IoctlData data, bool for_recording) {
         long transferred = 0;
 
@@ -135,10 +131,10 @@ internal class IoctlSpiHandler : IoctlSpiBase {
     long replay_chunk;
     long replay_byte;
 
-    public IoctlSpiHandler(MainContext? ctx, string file)
+    public IoctlSpiHandler(string file)
     {
         string val;
-        base (ctx);
+        base ();
 
         // Open SPI file
         try {
@@ -336,9 +332,9 @@ internal class IoctlSpiRecorder : IoctlSpiBase {
     bool cs_is_high;
     Posix.FILE log;
 
-    public IoctlSpiRecorder(MainContext? ctx, string device, string file)
+    public IoctlSpiRecorder(string device, string file)
     {
-        base (ctx);
+        base ();
 
         // Open SPI log file
         cs_is_high = false;

--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -764,6 +764,7 @@ public class Testbed: GLib.Object {
      * support.
      *
      * Returns: %TRUE on success, %FALSE on error.
+     * Since: 0.16
      */
     public bool attach_ioctl (string dev, IoctlBase handler) throws GLib.Error
     {
@@ -788,6 +789,7 @@ public class Testbed: GLib.Object {
      * if the path is not currently attached.
      *
      * Returns: %TRUE on success, %FALSE on error.
+     * Since: 0.16
      */
     public bool detach_ioctl (string dev) throws GLib.Error
     {
@@ -899,6 +901,7 @@ public class Testbed: GLib.Object {
      * information.
      *
      * Returns: %TRUE on success, %FALSE if the recording could not be loaded
+     * Since: 0.16
      */
     public bool load_pcap (string sysfs, string recordfile) throws GLib.Error, FileError, IOError, RegexError
     {

--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -95,9 +95,9 @@ public class Testbed: GLib.Object {
         this.worker_thread = create_worker_thread(this.worker_loop);
 
         /* Create fallback ioctl handler */
-        IoctlBase handler = new IoctlBase(this.worker_ctx);
+        IoctlBase handler = new IoctlBase();
         string sockpath = Path.build_filename(this.root_dir, "ioctl", "_default");
-        handler.register_path("_default", sockpath);
+        handler.register_path(this.worker_ctx, "_default", sockpath);
 
         Environment.set_variable("UMOCKDEV_DIR", this.root_dir, true);
         debug("Created udev test bed %s", this.root_dir);
@@ -819,12 +819,12 @@ public class Testbed: GLib.Object {
 
         IoctlBase handler;
         if (format == "SPI")
-            handler = new IoctlSpiHandler(worker_ctx, dest);
+            handler = new IoctlSpiHandler(dest);
         else
-            handler = new IoctlTreeHandler(worker_ctx, dest);
+            handler = new IoctlTreeHandler(dest);
 
         string sockpath = Path.build_filename(this.root_dir, "ioctl", owned_dev);
-        handler.register_path(owned_dev, sockpath);
+        handler.register_path(this.worker_ctx, owned_dev, sockpath);
 
         return true;
     }
@@ -860,8 +860,8 @@ public class Testbed: GLib.Object {
 
         assert(DirUtils.create_with_parents(Path.get_dirname(sockpath), 0755) == 0);
 
-        IoctlUsbPcapHandler handler = new IoctlUsbPcapHandler(worker_ctx, recordfile, busnum, devnum);
-        handler.register_path(owned_dev, sockpath);
+        IoctlUsbPcapHandler handler = new IoctlUsbPcapHandler(recordfile, busnum, devnum);
+        handler.register_path(this.worker_ctx, owned_dev, sockpath);
 
         return true;
     }


### PR DESCRIPTION
On top of #125 (sorry, but need fixes from there to make sense).

API is not optimal yet:
 * We could remove the main context from the `IoctlBase` initialisation, then pass it when attaching the device
 * Then we can hide it completely (or at least provide a good default)
 * detach requires passing the handler again; we could just hide that behind a hash table for lookup

But, works nicely.