### PR TITLE
test: Relax exit code comparison in /umockdev-record/script-log-append-dev-mismatch

### DIFF
--- a/tests/test-umockdev-record.vala
+++ b/tests/test-umockdev-record.vala
@@ -323,7 +323,7 @@ t_system_ioctl_log_append_dev_mismatch ()
     spawn ("umockdev-record" + " -i /dev/null=" + log + " -- " + readbyte_path + " /dev/null",
            out sout, out serr, out exit);
     assert (serr.contains ("two different devices"));
-    assert_cmpint (exit, CompareOperator.EQ, 133);
+    assert_cmpint (exit, CompareOperator.NE, 0);
     assert_cmpstr (sout, CompareOperator.EQ, "\0");
 
     // should not change original record


### PR DESCRIPTION
Commit e4ea3a7198 introduced a very strict comparison. But in different
build environment (such as Debian experimental buildds) this ends up as
5 instead of 133, as the 0x80 signal mask is not present for some
reason.

The precise value is not important, we just want to make sure it fails,
so relax the check.

-----

This should fix the [debian experimental failure](https://buildd.debian.org/status/fetch.php?pkg=umockdev&arch=amd64&ver=0.16.0-1&stamp=1625132699&raw=0). It failed on [almost all architectures](https://buildd.debian.org/status/package.php?p=umockdev&suite=experimental). I can't reproduce this locally in a Debian experimental container.