### PR TITLE
ioctl: Fix ioctl.h include location

### DIFF
--- a/src/ioctl.vapi
+++ b/src/ioctl.vapi
@@ -46,13 +46,13 @@ namespace Ioctl {
     [CCode (cheader_filename = "linux/usbdevice_fs.h")]
     public const int USBDEVFS_CAP_SUSPEND;
 
-    [CCode (cheader_filename = "asm-generic/ioctl.h")]
+    [CCode (cheader_filename = "asm/ioctl.h")]
     public const int _IOC_SIZEBITS;
-    [CCode (cheader_filename = "asm-generic/ioctl.h")]
+    [CCode (cheader_filename = "asm/ioctl.h")]
     public const int _IOC_SIZESHIFT;
-    [CCode (cheader_filename = "asm-generic/ioctl.h")]
+    [CCode (cheader_filename = "asm/ioctl.h")]
     public const int _IOC_TYPEBITS;
-    [CCode (cheader_filename = "asm-generic/ioctl.h")]
+    [CCode (cheader_filename = "asm/ioctl.h")]
     public const int _IOC_TYPESHIFT;
 
     [CCode (cname="struct usbdevfs_connectinfo", cheader_filename = "linux/usbdevice_fs.h")]


### PR DESCRIPTION
Including ioctl.h from asm-generic is not correct, as it will pick up
the wrong constants on some architectures. As such, include asm/ioctl.h
to avoid randomly overriding the values of some constants.

This fixes ppc64le.