### PR TITLE
docs: Remove types handling from docs

### DIFF
--- a/docs/reference/meson.build
+++ b/docs/reference/meson.build
@@ -14,7 +14,6 @@ gnome.gtkdoc('umockdev',
   src_dir: [meson.build_root(), umockdev_c, umockdev_ioctl_c],
   content_files: [version_xml],
   ignore_headers: ['uevent_sender.h', 'ioctl_tree.h', 'debug.h'],
-  scan_args: ['--rebuild-types'],
   dependencies: [glib, gobject, declare_dependency(link_with : [umockdev_lib])],
   install: true,
 )

--- a/docs/reference/umockdev-docs.xml
+++ b/docs/reference/umockdev-docs.xml
@@ -33,10 +33,6 @@
         <xi:include href="xml/umockdeverror.xml"/>
 
   </chapter>
-  <chapter id="object-tree">
-    <title>Object Hierarchy</title>
-     <xi:include href="xml/tree_index.sgml"/>
-  </chapter>
   <index id="api-index-full">
     <title>API Index</title>
     <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>


### PR DESCRIPTION
umockdev doesn't export any GObject object types, so gtk-doc should not
be trying to create an empty types file, or including an object class
tree in its documentation.

See https://gitlab.gnome.org/GNOME/gtk-doc/issues/48
See https://github.com/mesonbuild/meson/issues/3892
See https://bugzilla.redhat.com/show_bug.cgi?id=1604585