### PR TITLE
docs: Work-around creation of umockdev.types

### DIFF
--- a/docs/reference/meson.build
+++ b/docs/reference/meson.build
@@ -3,18 +3,13 @@ version_xml = configure_file(
   output: 'version.xml',
   configuration: conf)
 
-# HACK: need to find valac'ed umockdev.c for gtk-doc; https://github.com/mesonbuild/meson/issues/3892
-# this isn't predictable between meson versions
-umockdev_c = run_command('sh', '-ec', 'find -name umockdev.c| xargs dirname').stdout().strip()
-umockdev_ioctl_c = run_command('sh', '-ec', 'find -name umockdev-ioctl.c| xargs dirname').stdout().strip()
-
 gnome = import('gnome')
 gnome.gtkdoc('umockdev',
   main_xml: 'umockdev-docs.xml',
-  src_dir: [meson.build_root(), umockdev_c, umockdev_ioctl_c],
+  src_dir: [meson.build_root()],
   content_files: [version_xml],
+  gobject_typesfile: 'umockdev.types',
   ignore_headers: ['uevent_sender.h', 'ioctl_tree.h', 'debug.h'],
-  scan_args: ['--rebuild-types'],
   dependencies: [glib, gobject, declare_dependency(link_with : [umockdev_lib])],
   install: true,
 )

--- a/docs/reference/umockdev.types
+++ b/docs/reference/umockdev.types
@@ -1,0 +1,4 @@
+umockdev_ioctl_base_get_type
+umockdev_ioctl_client_get_type
+umockdev_ioctl_data_get_type
+umockdev_testbed_get_type


### PR DESCRIPTION
meson doesn't seem to have a way to tell gtk-doc where the .c files to
extract the type functions from would be when they're generated, like
they are for Vala sources.

Work around this by providing a static .types file.

See https://github.com/mesonbuild/meson/issues/3892

(Take 2, CC @benzea )