### PR TITLE
Testbed: Create "bus" and "class" dirs at init

### DIFF
--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -87,6 +87,12 @@ public class Testbed: GLib.Object {
         this.sys_dir = Path.build_filename(this.root_dir, "sys");
         DirUtils.create(this.sys_dir, 0755);
 
+        /* Create "bus" and "class" directories to make libudev happy */
+        string bus_path = Path.build_filename(this.sys_dir, "bus");
+        DirUtils.create(bus_path, 0755);
+        string class_path = Path.build_filename(this.sys_dir, "class");
+        DirUtils.create(class_path, 0755);
+
         this.dev_fd = new HashTable<string, int> (str_hash, str_equal);
         this.dev_script_runner = new HashTable<string, ScriptRunner> (str_hash, str_equal);
         this.custom_handlers = new HashTable<string, IoctlBase> (str_hash, str_equal);

--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -159,23 +159,20 @@ t_testbed_fs_ops ()
   assert_cmpstr (syspath, CompareOperator.EQ, "/sys/devices/dev1");
 
   // absolute paths
-  assert_listdir ("/sys", {"bus", "devices"});
+  assert_listdir ("/sys", {"bus", "class", "devices"});
   assert_listdir ("/sys/devices", {"dev1"});
   assert_listdir ("/sys/bus", {"pci"});
   assert_listdir ("/sys/devices/dev1", {"a", "subsystem", "uevent"});
 
   // change directory into trapped /sys
   assert_cmpint (Posix.chdir ("/sys"), CompareOperator.EQ, 0);
-  assert_listdir (".", {"bus", "devices"});
+  assert_listdir (".", {"bus", "class", "devices"});
   assert_listdir ("bus", {"pci"});
   assert_cmpstr (Environment.get_current_dir (), CompareOperator.EQ, "/sys");
 
   assert_cmpint (Posix.chdir ("/sys/devices/dev1"), CompareOperator.EQ, 0);
   assert_listdir (".", {"a", "subsystem", "uevent"});
   assert_cmpstr (Environment.get_current_dir (), CompareOperator.EQ, "/sys/devices/dev1");
-
-  assert_cmpint (Posix.chdir ("/sys/class"), CompareOperator.EQ, -1);
-  assert_cmpint (Posix.errno, CompareOperator.EQ, Posix.ENOENT);
 
   // relative paths into trapped /sys; this only works if the real /sys exists, as otherwise realpath() fails in trap_path()
   if (!have_real_sys) {
@@ -184,12 +181,12 @@ t_testbed_fs_ops ()
   }
 
   assert_cmpint (Posix.chdir ("/"), CompareOperator.EQ, 0);
-  assert_listdir ("sys", {"bus", "devices"});
+  assert_listdir ("sys", {"bus", "class", "devices"});
   assert_listdir ("sys/devices", {"dev1"});
   assert_listdir ("sys/bus", {"pci"});
 
   assert_cmpint (Posix.chdir ("/etc"), CompareOperator.EQ, 0);
-  assert_listdir ("../sys", {"bus", "devices"});
+  assert_listdir ("../sys", {"bus", "class", "devices"});
   assert_listdir ("../sys/devices", {"dev1"});
   assert_listdir ("../sys/bus", {"pci"});
 


### PR DESCRIPTION
libudev expects the "/sys/bus" and "/sys/class" directories to exist when calling `udev_enumerate_scan_devices()`. When this was called on an empty `Testbed`, it would return `-ENOENT` since these directories did not exist.

This fixes the issue by creating the "/sys/bus" and "/sys/class" at the same time that "/sys" is created in the `Testbed`.

`num_udev_devices()` is modified to call `udev_enumerate_scan_devices()` directly instead of using GUdev, which ignores the return value of `udev_enumerate_scan_devices()`. This makes `t_testbed_empty()` a valid test for the bug we are fixing.

Some vala tests also had to be modified to account for the change.

Fixes: https://github.com/martinpitt/umockdev/issues/144