### PR TITLE
Link umockdev-record with libumockdev

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -163,15 +163,9 @@ umockdev_run_exe = executable('umockdev-run',
   install: true)
 
 umockdev_record_exe = executable('umockdev-record',
-  ['src/umockdev-record.vala',
-   'src/umockdev-ioctl.vala',
-   'src/umockdev-pcap.vala',
-   'src/umockdev-spi.vala',
-   'src/ioctl_tree.vapi',
-   'src/ioctl_tree.c',
-   'src/debug.c'],
+  ['src/umockdev-record.vala'],
   dependencies: [glib, gobject, gio_unix, vapi_posix, vapi_config, vapi_ioctl, libpcap],
-  link_with: [umockdev_utils_lib],
+  link_with: [umockdev_utils_lib, umockdev_lib],
   vala_args: [ '--vapidir=@0@/src'.format(meson.current_source_dir()) ],
   include_directories: include_directories('src'),
   install: true)

--- a/src/umockdev-ioctl.vala
+++ b/src/umockdev-ioctl.vala
@@ -741,7 +741,7 @@ public class IoctlBase: GLib.Object {
           listeners.remove(devnode);
     }
 
-    internal void register_path(GLib.MainContext? ctx, string devnode, string sockpath)
+    public void register_path(GLib.MainContext? ctx, string devnode, string sockpath)
     {
         assert(DirUtils.create_with_parents(Path.get_dirname(sockpath), 0755) == 0);
 
@@ -768,13 +768,13 @@ public class IoctlBase: GLib.Object {
         ctx.invoke(tmp.cb);
     }
 
-    internal void unregister_path(string devnode)
+    public void unregister_path(string devnode)
     {
         lock (listeners)
           listeners[devnode].cancel();
     }
 
-    internal void unregister_all()
+    public void unregister_all()
     {
         lock (listeners) {
             listeners.foreach((key, val) => {
@@ -895,7 +895,7 @@ internal class IoctlTreeHandler : IoctlBase {
     }
 }
 
-internal class IoctlTreeRecorder : IoctlBase {
+public class IoctlTreeRecorder : IoctlBase {
 
     bool write_log;
     string logfile;

--- a/src/umockdev-spi.vala
+++ b/src/umockdev-spi.vala
@@ -69,7 +69,7 @@ private struct TransferChunk {
     bool cont;
 }
 
-internal abstract class IoctlSpiBase : IoctlBase {
+public abstract class IoctlSpiBase : IoctlBase {
 
     internal long iter_ioctl_vector(ulong count, IoctlData data, bool for_recording) {
         long transferred = 0;
@@ -325,7 +325,7 @@ internal class IoctlSpiHandler : IoctlSpiBase {
     }
 }
 
-internal class IoctlSpiRecorder : IoctlSpiBase {
+public class IoctlSpiRecorder : IoctlSpiBase {
 
     bool cs_is_high;
     Posix.FILE log;


### PR DESCRIPTION
Avoid the duplicate static linking of the ioctl sources in
umockdev-record, and link it to libumockdev instead. The corresponding
symbols are already public in the C API anyway (as they match
src/umockdev.map), so just move the previously `internal`
classes/methods to `public`.

This also avoids confusing complaints about allegedly unused methods.

Fixes #138