### PR TITLE
test: Don't check HIDIOCGRDESCSIZE result on big-endian machines

### DIFF
--- a/src/umockdev-spi.vala
+++ b/src/umockdev-spi.vala
@@ -74,11 +74,7 @@ internal abstract class IoctlSpiBase : IoctlBase {
     internal long iter_ioctl_vector(ulong count, IoctlData data, bool for_recording) {
         long transferred = 0;
 
-#if G_BYTE_ORDER != G_LITTLE_ENDIAN
-        // This only works on little endian or 64bit.
-        assert(sizeof(void*) == sizeof(uint64));
-#endif
-
+        // This only works on 64bit machines
         for (long i = 0; i < count; i++) {
             unowned IoctlData tx = null, rx = null;
             Ioctl.spi_ioc_transfer *transfer = &((Ioctl.spi_ioc_transfer[]) data.data)[i];

--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -705,8 +705,8 @@ t_hidraw_ioctl ()
   int i = 0;
   assert_cmpint (Posix.ioctl (fd, Ioctl.HIDIOCGRDESCSIZE, ref i), CompareOperator.EQ, 0);
   assert_cmpint (Posix.errno, CompareOperator.EQ, 0);
-  // HACK: This actually works fine on real s390x (big endian), but fails in emulated QEMU (such as COPR)
-  if (Environment.get_variable ("RPM_ARCH") != "s390x")
+  // HACK: This is broken on big-endian machines like s390x and ppc64, it is 0x22000000 there
+  if (BYTE_ORDER == ByteOrder.LITTLE_ENDIAN)
       assert_cmpint (i, CompareOperator.EQ, 34);
   Ioctl.hidraw_report_descriptor desc = { 34, };
   assert_cmpint (Posix.ioctl (fd, Ioctl.HIDIOCGRDESC, ref desc), CompareOperator.EQ, 0);


### PR DESCRIPTION
Adjust commit 0da63a9259: Turns out that HIDIOCGRDESCSIZE is generally
broken on big-endian machines, it fails the same way on real-iron s390x
and also ppc64.

---

[ubuntu s390x failure](https://launchpadlibrarian.net/579523463/buildlog_ubuntu-jammy-s390x.umockdev_0.17.2-1_BUILDING.txt.gz), [Debian ppc64 failure](https://buildd.debian.org/status/fetch.php?pkg=umockdev&arch=ppc64&ver=0.17.2-1&stamp=1641805816&raw=0), [Debian s390x failure](https://buildd.debian.org/status/fetch.php?pkg=umockdev&arch=s390x&ver=0.17.2-1&stamp=1641804671&raw=0)