### PR TITLE
Include udev properties in emulated netlink messages

### DIFF
--- a/src/uevent_sender.c
+++ b/src/uevent_sender.c
@@ -209,14 +209,16 @@ append_property(char *array, size_t size, size_t offset, const char *name, const
         fprintf(stderr, "ERROR: snprintf failed");
         abort();
     }
-    // include the NUL terminator in the string length, as we need to keep it as a separator between keys
-    ++r;
     if (r + offset >= size) {
         fprintf(stderr, "ERROR: uevent_sender_send: Property buffer overflow\n");
         abort();
-     }
+    }
 
-    return r;
+    /* this is already true as snprintf always writes the NUL, but -fanalyzer complains about use-of-uninitialized-value */
+    array[offset + r] = '\0';
+
+    /* include the NUL terminator in the string length, as we need to keep it as a separator between keys */
+    return r + 1;
 }
 
 /* this mirrors the code from systemd/src/libsystemd/sd-device/device-monitor.c,

--- a/src/uevent_sender.c
+++ b/src/uevent_sender.c
@@ -205,6 +205,10 @@ append_property(char *array, size_t size, ssize_t offset, const char *name, cons
     int r;
     assert(offset < size);
     r = snprintf(array + offset, size - offset, "%s%s", name, value);
+    if (r < 0) {
+        fprintf(stderr, "ERROR: snprintf failed");
+        abort();
+    }
     // include the NUL terminator in the string length, as we need to keep it as a separator between keys
     ++r;
     if (r + offset >= size) {

--- a/src/uevent_sender.h
+++ b/src/uevent_sender.h
@@ -23,6 +23,6 @@ typedef struct _uevent_sender uevent_sender;
 
 uevent_sender *uevent_sender_open(const char *rootpath);
 void uevent_sender_close(uevent_sender * sender);
-void uevent_sender_send(uevent_sender * sender, const char *devpath, const char *action);
+void uevent_sender_send(uevent_sender * sender, const char *devpath, const char *action, const char *properties);
 
 #endif				/* __UEVENT_SENDER_H */

--- a/src/uevent_sender.vapi
+++ b/src/uevent_sender.vapi
@@ -6,6 +6,6 @@ namespace UeventSender {
   public class sender {
       [CCode (cname="uevent_sender_open")]
       public sender (string rootpath);
-      public void send (string devpath, string action);
+      public void send (string devpath, string action, string properties);
   }
 }

--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -754,7 +754,15 @@ public class Testbed: GLib.Object {
             assert(this.ev_sender != null);
         }
         debug("umockdev_testbed_uevent: sending uevent %s for device %s", action, devpath);
-        this.ev_sender.send(devpath, action);
+
+        var uevent_path = Path.build_filename(this.root_dir, devpath, "uevent");
+        var properties = "";
+        try {
+            FileUtils.get_contents(uevent_path, out properties);
+        } catch (FileError e) {
+            debug("uevent: devpath %s has no uevent file: %s",  devpath, e.message);
+        }
+        this.ev_sender.send(devpath, action, properties);
     }
 
     /**

--- a/tests/test-umockdev.c
+++ b/tests/test-umockdev.c
@@ -577,40 +577,6 @@ t_testbed_set_property(UMockdevTestbedFixture * fixture, UNUSED_DATA)
     g_object_unref(device);
 }
 
-struct event_counter {
-    unsigned add;
-    unsigned remove;
-    unsigned change;
-    gchar last_device[1024];
-};
-
-static void
-on_uevent(UNUSED GUdevClient *client, const gchar *action, GUdevDevice *device, gpointer user_data)
-{
-    struct event_counter *counter = (struct event_counter *)user_data;
-
-    g_debug("on_uevent action %s device %s", action, g_udev_device_get_sysfs_path(device));
-
-    if (strcmp(action, "add") == 0)
-	counter->add++;
-    else if (strcmp(action, "remove") == 0)
-	counter->remove++;
-    else if (strcmp(action, "change") == 0)
-	counter->change++;
-    else
-	g_assert_not_reached();
-
-    strncpy(counter->last_device, g_udev_device_get_sysfs_path(device), sizeof(counter->last_device) - 1);
-}
-
-static gboolean
-on_timeout(gpointer user_data)
-{
-    GMainLoop *mainloop = (GMainLoop *) user_data;
-    g_main_loop_quit(mainloop);
-    return FALSE;
-}
-
 static void
 t_testbed_uevent_libudev(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 {
@@ -719,6 +685,41 @@ t_testbed_uevent_libudev_filter(UMockdevTestbedFixture * fixture, UNUSED_DATA)
     udev_monitor_unref(mon);
     udev_unref(udev);
 }
+
+struct event_counter {
+    unsigned add;
+    unsigned remove;
+    unsigned change;
+    gchar last_device[1024];
+};
+
+static void
+on_uevent(UNUSED GUdevClient *client, const gchar *action, GUdevDevice *device, gpointer user_data)
+{
+    struct event_counter *counter = (struct event_counter *)user_data;
+
+    g_debug("on_uevent action %s device %s", action, g_udev_device_get_sysfs_path(device));
+
+    if (strcmp(action, "add") == 0)
+	counter->add++;
+    else if (strcmp(action, "remove") == 0)
+	counter->remove++;
+    else if (strcmp(action, "change") == 0)
+	counter->change++;
+    else
+	g_assert_not_reached();
+
+    strncpy(counter->last_device, g_udev_device_get_sysfs_path(device), sizeof(counter->last_device) - 1);
+}
+
+static gboolean
+on_timeout(gpointer user_data)
+{
+    GMainLoop *mainloop = (GMainLoop *) user_data;
+    g_main_loop_quit(mainloop);
+    return FALSE;
+}
+
 
 static void
 t_testbed_uevent_gudev(UMockdevTestbedFixture * fixture, UNUSED_DATA)

--- a/tests/test-umockdev.c
+++ b/tests/test-umockdev.c
@@ -614,12 +614,16 @@ t_testbed_uevent_libudev(UMockdevTestbedFixture * fixture, UNUSED_DATA)
     g_assert(device != NULL);
     g_assert_cmpstr(udev_device_get_syspath(device), ==, syspath);
     g_assert_cmpstr(udev_device_get_action(device), ==, "add");
+    g_assert_cmpstr(udev_device_get_sysattr_value(device, "idVendor"), ==, "0815");
+    g_assert_cmpstr(udev_device_get_property_value(device, "ID_INPUT"), ==, "1");
     udev_device_unref(device);
 
     device = udev_monitor_receive_device(kernel_mon);
     g_assert(device != NULL);
     g_assert_cmpstr(udev_device_get_syspath(device), ==, syspath);
     g_assert_cmpstr(udev_device_get_action(device), ==, "add");
+    g_assert_cmpstr(udev_device_get_sysattr_value(device, "idVendor"), ==, "0815");
+    g_assert_cmpstr(udev_device_get_property_value(device, "ID_INPUT"), ==, "1");
     udev_device_unref(device);
 
     udev_monitor_unref(udev_mon);


### PR DESCRIPTION
Current systemd by and large does not read the /uevent file any more,
but entirely relies on udevd sending the properties in the udev netlink
events.

Pass the properties to uevent_sender_send(), massage them from a
newline separated (as in our uevent file) to a nul separated (as
expected by the udev netlink message) array. In Testbed.uevent(), read
the current properties from the /uevent file.

This is all rather hackish right now and cries for a more thorough
rewrite. But this is a relatively unintrusive and quick bandaid which
helps users for the time being.

Test this both with the libudev and with the gudev (through Python) APIs.

Fixes #164