### PR TITLE
uevent_sender: Increase buffer size

### DIFF
--- a/src/uevent_sender.c
+++ b/src/uevent_sender.c
@@ -33,6 +33,8 @@
 #include "utils.h"
 #include "uevent_sender.h"
 
+#define UEVENT_BUFSIZE 16384
+
 struct _uevent_sender {
     char *rootpath;
     char socket_glob[PATH_MAX];
@@ -226,7 +228,7 @@ append_property(char *array, size_t size, size_t offset, const char *name, const
 void
 uevent_sender_send(uevent_sender * sender, const char *devpath, const char *action, const char *properties)
 {
-    char buffer[1024];
+    char buffer[UEVENT_BUFSIZE];
     size_t buffer_len = 0;
     struct msghdr smsg;
     struct iovec iov[2];

--- a/tests/test-umockdev.c
+++ b/tests/test-umockdev.c
@@ -857,6 +857,25 @@ t_testbed_uevent_action_overflow(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 }
 
 static void
+t_testbed_uevent_property_overflow(UMockdevTestbedFixture * fixture, UNUSED_DATA)
+{
+    /* overly long property */
+    if (g_test_subprocess()) {
+        char long_name[800];
+        memset(long_name, 'a', sizeof long_name);
+        long_name[sizeof long_name - 1] = '\0';
+
+        /* this sends an "add" uevent */
+        umockdev_testbed_add_device(fixture->testbed, "pci", "mydev", NULL,
+                                    NULL, /* attributes */
+                                    long_name, long_name, NULL);
+    }
+    g_test_trap_subprocess(NULL, 0, 0);
+    g_test_trap_assert_failed();
+    g_test_trap_assert_stderr ("*uevent_sender_send*Property buffer overflow*");
+}
+
+static void
 t_testbed_add_from_string(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 {
     GUdevDevice *device;
@@ -2305,6 +2324,8 @@ main(int argc, char **argv)
 	       t_testbed_uevent_null_action, t_testbed_fixture_teardown);
     g_test_add("/umockdev-testbed/uevent/action_overflow", UMockdevTestbedFixture, NULL, t_testbed_fixture_setup,
 	       t_testbed_uevent_action_overflow, t_testbed_fixture_teardown);
+    g_test_add("/umockdev-testbed/uevent/property_overflow", UMockdevTestbedFixture, NULL, t_testbed_fixture_setup,
+	       t_testbed_uevent_property_overflow, t_testbed_fixture_teardown);
 
     /* tests for mocking USB devices */
     g_test_add("/umockdev-testbed-usb/lsusb", UMockdevTestbedFixture, NULL, t_testbed_fixture_setup,

--- a/tests/test-umockdev.c
+++ b/tests/test-umockdev.c
@@ -846,7 +846,7 @@ t_testbed_uevent_action_overflow(UMockdevTestbedFixture * fixture, UNUSED_DATA)
 
     /* overly long action */
     if (g_test_subprocess()) {
-        char long_action[4096];
+        char long_action[16384];
         memset(long_action, 'a', sizeof(long_action));
         long_action[sizeof(long_action)-1] = '\0';
         umockdev_testbed_uevent(fixture->testbed, syspath, long_action);
@@ -861,7 +861,7 @@ t_testbed_uevent_property_overflow(UMockdevTestbedFixture * fixture, UNUSED_DATA
 {
     /* overly long property */
     if (g_test_subprocess()) {
-        char long_name[800];
+        char long_name[10000];
         memset(long_name, 'a', sizeof long_name);
         long_name[sizeof long_name - 1] = '\0';
 


### PR DESCRIPTION
Some tests need more than 1 KiB of property data.
Fixes #167