### PR TITLE
Mark /umockdev-testbed-vala/detects_running_outside_testbed as brittle

### DIFF
--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -793,9 +793,8 @@ t_detects_running_in_testbed ()
 void
 t_detects_not_running_in_testbed ()
 {
-
-    if (Environment.get_variable ("RPM_ARCH") == "s390x" || Environment.get_variable ("RPM_ARCH") == "arm") {
-        stdout.printf ("[SKIP: test known broken in emulated architectures on koji] ");
+    if (Environment.get_variable ("BRITTLE_TESTS") == null) {
+        stdout.printf ("[SKIP: brittle test: does not work on emulated architectures] ");
         stdout.flush ();
         return;
     }


### PR DESCRIPTION
This also fails in some riscv64 builds (not in Debian's or Ubuntu's,
though). This failure is hard to reproduce, it even passes with

    sudo systemd-run -p CPUQuota=1% -dt --wait sh -ec 'LD_LIBRARY_PATH=. LD_PRELOAD=libumockdev-preload.so ./test-umockdev-vala -p /umockdev-testbed-vala/detects_running_outside_testbed'

So mark it as brittle for now to skip it in normal package builds.

Fixes #169