### PR TITLE
packit: Drop obsolete fields

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -1,17 +1,11 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
-specfile_path: packaging/umockdev.spec
 upstream_project_url: https://github.com/martinpitt/umockdev
 issue_repository: https://github.com/martinpitt/umockdev
 copy_upstream_release_description: true
 upstream_package_name: umockdev
 downstream_package_name: umockdev
 srpm_build_deps: []
-
-files_to_sync:
-  - packit.yaml
-  - src: packaging/umockdev.spec
-    dest: umockdev.spec
 
 jobs:
   - job: copr_build


### PR DESCRIPTION
 - `specfile_path` searches the tree for a .spec, and thus should be
   able to find it in packaging/ by itself.
 - `files_to_sync` already defaults to syncing the packit YAML and the
   spec, but this was broken for a few days
   (https://github.com/packit/packit/issues/1525)