### PR TITLE
Environment API

### DIFF
--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -149,7 +149,23 @@ public class Testbed: GLib.Object {
     }
 
     /**
-     * umockdev_testbed_get_root_dir:
+     * umockdev_testbed_get_environ:
+     * @self: A #UMockdevTestbed.
+     *
+     * Return the environment as it should be set for child processes.
+     *
+     * Returns: List of environment variables and their values.
+     */
+   [CCode (array_length = false, array_null_terminated = true)]
+    public string[] get_environ()
+    {
+        return {
+            "UMOCKDEV_DIR=%s".printf(this.root_dir),
+        };
+    }
+
+    /**
+     * umockdev_testbed_get_environment:
      * @self: A #UMockdevTestbed.
      *
      * Get the root directory for the testbed. This is mostly useful for

--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -87,6 +87,10 @@ public class Testbed: GLib.Object {
         this.sys_dir = Path.build_filename(this.root_dir, "sys");
         DirUtils.create(this.sys_dir, 0755);
 
+        if (FileUtils.symlink("/sys/fs", Path.build_filename(this.sys_dir, "fs")) < 0) {
+            error("Cannot create symlink to host /sys/fs: %s", strerror(errno));
+        }
+
         /* Create "bus" and "class" directories to make libudev happy */
         string bus_path = Path.build_filename(this.sys_dir, "bus");
         DirUtils.create(bus_path, 0755);

--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -159,14 +159,14 @@ t_testbed_fs_ops ()
   assert_cmpstr (syspath, CompareOperator.EQ, "/sys/devices/dev1");
 
   // absolute paths
-  assert_listdir ("/sys", {"bus", "class", "devices"});
+  assert_listdir ("/sys", {"bus", "class", "devices", "fs"});
   assert_listdir ("/sys/devices", {"dev1"});
   assert_listdir ("/sys/bus", {"pci"});
   assert_listdir ("/sys/devices/dev1", {"a", "subsystem", "uevent"});
 
   // change directory into trapped /sys
   assert_cmpint (Posix.chdir ("/sys"), CompareOperator.EQ, 0);
-  assert_listdir (".", {"bus", "class", "devices"});
+  assert_listdir (".", {"bus", "class", "devices", "fs"});
   assert_listdir ("bus", {"pci"});
   assert_cmpstr (Environment.get_current_dir (), CompareOperator.EQ, "/sys");
 
@@ -181,12 +181,12 @@ t_testbed_fs_ops ()
   }
 
   assert_cmpint (Posix.chdir ("/"), CompareOperator.EQ, 0);
-  assert_listdir ("sys", {"bus", "class", "devices"});
+  assert_listdir ("sys", {"bus", "class", "devices", "fs"});
   assert_listdir ("sys/devices", {"dev1"});
   assert_listdir ("sys/bus", {"pci"});
 
   assert_cmpint (Posix.chdir ("/etc"), CompareOperator.EQ, 0);
-  assert_listdir ("../sys", {"bus", "class", "devices"});
+  assert_listdir ("../sys", {"bus", "class", "devices", "fs"});
   assert_listdir ("../sys/devices", {"dev1"});
   assert_listdir ("../sys/bus", {"pci"});
 

--- a/tests/test-umockdev.c
+++ b/tests/test-umockdev.c
@@ -145,7 +145,14 @@ num_udev_devices(void)
 static void
 t_testbed_empty(UNUSED UMockdevTestbedFixture *fixture, UNUSED_DATA)
 {
+    g_auto(GStrv) environ = NULL;
+    g_autofree char *env_umockdevdir = g_strdup_printf ("UMOCKDEV_DIR=%s", fixture->root_dir);
+
     g_assert_cmpuint(num_udev_devices(), ==, 0);
+
+    environ = umockdev_testbed_get_environ (fixture->testbed);
+    g_assert_cmpstr (environ[0], ==, env_umockdevdir);
+    g_assert_cmpstr (environ[1], ==, NULL);
 }
 
 /* common checks for umockdev_testbed_add_device{,v}() */


### PR DESCRIPTION
So, this adds a function returning an `char**` (same as `g_get_environ`).

Not sure what makes sense though. In python returning a dictionary would be more convenient. So maybe we should just expose both types of utility functions. This and a `GHashtTable` return or so.

Or just hash table.

Note that I kind of tried to get things to work using an xattr instead. But, turns out, tmpfs does not allow setting arbitrary values. I did manage to get it to run (except for nix) by setting a special ACL on the file (`system.posix_acl_access` xattr), but that is just one bit of information, which could probable be done using a sticky bit already ...

Or we could touch a `.umockdev` file in every device node, and then `openat(fd, ".umockdev")` to decide on whether to override ...

In conclusion, lets just do this, everything else is complicated and with questionable benefits.