### PR TITLE
preload: Wrap fstatfs()

### DIFF
--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -106,9 +106,6 @@ public class Testbed: GLib.Object {
         string sockpath = Path.build_filename(this.root_dir, "ioctl", "_default");
         handler.register_path(this.worker_ctx, "_default", sockpath);
 
-        // disable sd-device's "is this really sysfs" check
-        Environment.set_variable("SYSTEMD_DEVICE_VERIFY_SYSFS", "0", false);
-
         Environment.set_variable("UMOCKDEV_DIR", this.root_dir, true);
         debug("Created udev test bed %s", this.root_dir);
     }


### PR DESCRIPTION
Revert commit 4b1ab11c244a0a488bb. Merely setting
`$SYSTEMD_DEVICE_VERIFY_SYSFS` does not work for GI bindings. Instead,
wrap fstatfs() and mangle the type to SYSFS_MAGIC if the path points
into our mocked /sys. This satisfies udev.

Fixes https://github.com/systemd/systemd/issues/23499