### PR TITLE
ioctl: Make data object usable from python

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,8 @@ add_project_arguments(
   '-Wno-error=pragmas',
   language: 'c')
 
+add_project_arguments('--abi-stability', language: 'vala')
+
 # let's not clutter the code with too many #ifdefs
 if get_option('b_ndebug') == 'true'
   add_project_arguments('-Wno-error=unused-but-set-variable', '-Wno-error=unused-variable', language: 'c')

--- a/tests/test-umockdev.py
+++ b/tests/test-umockdev.py
@@ -243,4 +243,8 @@ A: simple_attr=1
         arg = struct.unpack('l', arg)[0]
         self.assertEqual(arg, 1)
 
+        # Check that an detach/attach works
+        self.testbed.detach_ioctl('/dev/test')
+        self.testbed.attach_ioctl('/dev/test', handler)
+
 unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout, verbosity=2))


### PR DESCRIPTION
So, things are not usable from python. Thing still broken:
 * We need the old _ref/_unref functions for API compatibility if we use a GObject, not sure how to do that. Or can we use a boxed type?
 * The length of data is not tagged in the GIR

So, kinda works, but you can't actually read the memory. And, not sure if maybe a `ctypes.memmove` shouldn't be workable instead.


The bindings cannot deal with a struct object, as it is not a boxed type
and it'll try to ref/unref using g_object_ref. Probably this is
fixable in another way, but this works.

Also, the python bindings cannot modify the byte data directly, so add
an update method that is essentially a glorified memcpy.