### PR TITLE
spec: Be generous with slow test timeouts

### DIFF
--- a/packaging/umockdev.spec
+++ b/packaging/umockdev.spec
@@ -39,6 +39,9 @@ using %{name}.
 %meson_build
 
 %check
+# don't be too picky about timing; upstream CI and local developer tests
+# are strict, but many koji arches are emulated and utterly slow
+export SLOW_TESTBED_FACTOR=10
 %meson_test
 
 %install

--- a/tests/test-umockdev-run.vala
+++ b/tests/test-umockdev-run.vala
@@ -591,7 +591,8 @@ t_input_touchpad ()
     checked_remove (logfile);
     checked_remove (logfile + ".old");
     // clean up lockfile after killed X server
-    checked_remove ("/tmp/.X5-lock");
+    if (FileUtils.remove ("/tmp/.X5-lock") < 0)
+        debug("failed to clean up /tmp/.X5-lock: %m");
     checked_remove ("/tmp/.X11-unix/X5");
 
     assert_cmpstr (xinput_err, CompareOperator.EQ, "");


### PR DESCRIPTION
Many koji architectures are emulated, especially in Pagure/packit builds. Don't be too picky about the timing there, similar to what we do in Debian autopkgtest.