### PR TITLE
test: Allow missing .X11-unix/X5 file

### DIFF
--- a/tests/test-umockdev-run.vala
+++ b/tests/test-umockdev-run.vala
@@ -593,7 +593,8 @@ t_input_touchpad ()
     // clean up lockfile after killed X server
     if (FileUtils.remove ("/tmp/.X5-lock") < 0)
         debug("failed to clean up /tmp/.X5-lock: %m");
-    checked_remove ("/tmp/.X11-unix/X5");
+    if (FileUtils.remove ("/tmp/.X11-unix/X5") < 0)
+        debug("failed to clean up .X11-unix/X5: %m");
 
     assert_cmpstr (xinput_err, CompareOperator.EQ, "");
     assert_cmpint (xinput_exit, CompareOperator.EQ, 0);


### PR DESCRIPTION
Closes #208

Testing fails with

    cannot remove /tmp/.X11-unix/X5: No such file or directory

Fixes: 0f686e11540c ("Check FileUtils.{remove,unlink}() return code")