### PR TITLE
preload: Don't read udev cache data from system

### DIFF
--- a/src/libumockdev-preload.c
+++ b/src/libumockdev-preload.c
@@ -185,6 +185,8 @@ trap_path(const char *path)
 
     if (strncmp(abspath, "/dev/", 5) == 0 || strcmp(abspath, "/dev") == 0 || strncmp(abspath, "/proc/", 6) == 0)
 	check_exist = 1;
+    else if (strncmp(abspath, "/run/udev/data", 14) == 0)
+	check_exist = 0;
     else if (strncmp(abspath, "/sys/", 5) != 0 && strcmp(abspath, "/sys") != 0)
 	return path;
 


### PR DESCRIPTION
Never read the udev cache data from the system, as this might make properties of system devices leak through our mocked udev, such as headsets showing up as internal devices.

Closes: https://github.com/martinpitt/umockdev/issues/213