### PR TITLE
test: Use g_get_tmp_dir()

### DIFF
--- a/tests/test-umockdev.c
+++ b/tests/test-umockdev.c
@@ -1394,7 +1394,7 @@ t_testbed_dev_access(UMockdevTestbedFixture * fixture, UNUSED_DATA)
     /* open() with O_TMPFILE; this hasn't been supported in Linux for very long
      * (>= 3.11), so check that it works in the testbed only if it also works
      * in the "normal" file system. */
-    fd = g_open("/tmp", O_TMPFILE|O_RDWR, 0644);
+    fd = g_open(g_get_tmp_dir(), O_TMPFILE|O_RDWR, 0644);
     if (fd >= 0) {
         close(fd);
         errno = 0;


### PR DESCRIPTION
This ensures that the emulated /dev (which is created in `g_get_tmp_dir()` via `DirUtils.make_tmp()` and the feature check are done in the same directory. If `$TMPDIR` is set, that may not be the case.

Fixes #217