### PR TITLE
Make vala C code errors non-fatal

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,6 @@ add_project_arguments(
   '-Werror=format-security',
   '-Werror=format=2',
   #'-Werror=missing-include-dirs',
-  '-Werror=unused-variable',
   '-Werror=return-type',
   '-Werror=uninitialized',
   # experimental: first check this on all Debian architectures
@@ -32,30 +31,23 @@ add_project_arguments(
 
 add_project_arguments('--abi-stability', language: 'vala')
 
-# let's not clutter the code with too many #ifdefs
-if get_option('b_ndebug') == 'true'
-  add_project_arguments('-Wno-error=unused-but-set-variable', '-Wno-error=unused-variable', language: 'c')
-endif
-
-# HACK: between Jan 5 and Jan 8 2024, Gentoo changed something that causes
-# hundreds of warnings when compiling the vala-generated C code; ignore these
-if get_option('gentoo-hacks')
-  add_project_arguments(
-    '-Wno-error',
-    '-Wno-error=incompatible-pointer-types',
-    '-Wno-error=pointer-sign',
-    '-Wno-error=unused-function',
-    '-Wno-error=unused-label',
-    '-Wno-error=unused-but-set-variable',
-    '-Wno-error=unused-variable',
-    '-Wno-error=unused-value',
-    language: 'c')
-endif
-
 conf = configuration_data()
 cc = meson.get_compiler('c')
 valac = meson.get_compiler('vala')
 g_ir_compiler = find_program('g-ir-compiler', required: false)
+
+# generated vala code triggers tons of these
+add_project_arguments(
+  cc.get_supported_arguments(
+    '-Wno-error=discarded-qualifiers',
+    '-Wno-error=incompatible-pointer-types',
+    '-Wno-error=pointer-sign',
+    '-Wno-error=unused-but-set-variable',
+    '-Wno-error=unused-function',
+    '-Wno-error=unused-label',
+    '-Wno-error=unused-value',
+    '-Wno-error=unused-variable'
+  ), language: 'c')
 
 # HACK: vala doesn't support declaring const arguments, so we get a lot of errors
 if cc.get_id() == 'clang'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,8 +2,3 @@ option('gtk_doc',
        type : 'boolean',
        value : false,
        description : 'use gtk-doc to build documentation')
-
-option('gentoo-hacks',
-       type : 'boolean',
-       value : false,
-       description : 'disable gcc fatal warnings, for Gentoo builds')

--- a/src/umockdev-record.vala
+++ b/src/umockdev-record.vala
@@ -61,7 +61,7 @@ all_devices ()
 {
     var devs = new GenericArray<string>();
     devices_from_dir("/sys/devices", ref devs);
-    return devs.data;
+    return devs.steal();
 }
 
 // If dev is a block or character device, convert it to a sysfs path.

--- a/tests/run-gentoo
+++ b/tests/run-gentoo
@@ -27,7 +27,7 @@ git config --global safe.directory /source
 
 cd /source
 export VALAC=\$(ls /usr/bin/valac-* |sort | tail -n1)
-meson setup /tmp/dbg --buildtype debug --werror -Dgentoo-hacks=true
+meson setup /tmp/dbg --buildtype debug --werror
 
 export BRITTLE_TESTS="${BRITTLE_TESTS:-}"
 meson test -C /tmp/dbg -v --num-processes=1


### PR DESCRIPTION
meson 1.4 stopped hiding valac's warnings [1], which fails compilation
due to our `-Werror=` settings. There's not much that we can do at this
point, so stop making them non-fatal.

This reverts the `gentoo-hacks` option from commit 539af0b4f36. Turns
out that this wasn't a compiler change in Gentoo after all, but that
Gentoo backported [2] that meson change at that time.

Many thanks to Dominique Leuenberger @DimStar77 for tracking down the
root cause!

Fixes #228

[1] https://github.com/mesonbuild/meson/commit/5f659af870011e
[2] https://github.com/gentoo/gentoo/pull/34141