### PR TITLE
Skip usbfs_ioctl_pcap on sparc64

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -101,6 +101,7 @@ python = find_program('python3', 'python', required: false)
 vapi_posix = valac.find_library('posix')
 vapi_linux = valac.find_library('linux')
 vapi_linux_fixes = valac.find_library('linux_fixes', dirs: srcdir)
+vapi_glibc = valac.find_library('glibc', dirs: srcdir)
 vala_libudev = cc.find_library('udev')
 vala_libutil = cc.find_library('util')
 
@@ -278,7 +279,7 @@ if gudev.found()
 
   test('umockdev-vala', executable('test-umockdev-vala',
       'tests/test-umockdev-vala.vala',
-      dependencies: [glib, gobject, gio, gudev, vapi_posix, vapi_assertions, vapi_ioctl, vapi_selinux, selinux],
+      dependencies: [glib, gobject, gio, gudev, vapi_posix, vapi_assertions, vapi_ioctl, vapi_glibc, vapi_selinux, selinux],
       link_with: [umockdev_lib, umockdev_utils_lib],
       vala_args: optional_defines),
     depends: [preload_lib],

--- a/src/glibc.vapi
+++ b/src/glibc.vapi
@@ -1,0 +1,14 @@
+[CCode (cheader_filename = "sys/utsname.h")]
+namespace GLibc {
+    [CCode (cname = "struct utsname", destroy_function="")]
+    public struct Utsname {
+        unowned string sysname;
+        unowned string nodename;
+        unowned string release;
+        unowned string version;
+        unowned string machine;
+    }
+
+    [CCode (cname = "uname")]
+    public void uname (out Utsname buf);
+}

--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -20,6 +20,7 @@
 
 using UMockdevUtils;
 using Assertions;
+using GLibc;
 
 #if HAVE_SELINUX
 using Selinux;
@@ -548,6 +549,13 @@ t_usbfs_ioctl_pcap ()
   var tb = new UMockdev.Testbed ();
   string device;
   Ioctl.usbdevfs_urb* urb_reap = null;
+
+  GLibc.Utsname utsbuf;
+  GLibc.uname (out utsbuf);
+  if (utsbuf.machine ==  "sparc64") {
+      stdout.printf ("[SKIP pre-recorded pcap does not work on sparc64]\n");
+      return;
+  }
 
   /* NOTE: This test is a bit ugly. It wasn't the best idea to use a USB keyboard. */
 


### PR DESCRIPTION
Calling Ioctl.USBDEVFS_REAPURB in the test causes a SIGBUS error on sparc64. It's actually surprising that this test passes on a lot of architectures -- the pcap file was recorded on x86_64, and there may be some unaligned access there.

I don't know enough about compilers, alignment, and pcap files to actually fix this. But the more pressing issue is to fix the package build on sparc64.

Fixes #218