### PR TITLE
packit: Restrict koji_build and bodhi_update to Fedora

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -77,11 +77,13 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    packages: [umockdev-fedora]
     dist_git_branches:
       - fedora-all
 
   - job: bodhi_update
     trigger: commit
+    packages: [umockdev-fedora]
     dist_git_branches:
       # rawhide updates are created automatically
       - fedora-branched


### PR DESCRIPTION
While they are not directly related to building srpms, this caused the koji-build jobs to run twice, and thus creating confusing "Fedora Koji build failed to be triggered" issues.

Fixes #245