### PR TITLE
preload: fix sigmask block and restore race

### DIFF
--- a/src/libumockdev-preload.c
+++ b/src/libumockdev-preload.c
@@ -166,13 +166,13 @@ pthread_mutex_t ioctl_lock = PTHREAD_MUTEX_INITIALIZER;
     do { \
         sigset_t sig_set; \
         sigfillset(&sig_set); \
-        pthread_sigmask(SIG_SETMASK, &sig_set, &trap_path_sig_restore); \
         pthread_mutex_lock (&trap_path_lock); \
+        pthread_sigmask(SIG_SETMASK, &sig_set, &trap_path_sig_restore); \
     } while (0)
 #define TRAP_PATH_UNLOCK \
     do { \
-        pthread_mutex_unlock (&trap_path_lock); \
         pthread_sigmask(SIG_SETMASK, &trap_path_sig_restore, NULL); \
+        pthread_mutex_unlock (&trap_path_lock); \
     } while (0)
 
 #define IOCTL_LOCK pthread_mutex_lock (&ioctl_lock)


### PR DESCRIPTION
Related to and discussed more at https://github.com/martinpitt/umockdev/issues/252

---

To avoid clobbering a threads signal mask with that of another thread, take locks before storing a thread's signal mask in case another thread has already stored its own signal mask in the trap_path_sig_restore variable, but has not yet restored it.

Without this change, the following could happen:

If umockdev-run is used to run a process which spawns multiple threads, and each of those threads writes to a file, and has specific signal mask requirements, the following may happen

- Thread A: 
    - store thread A's sigmask in trap_path_sig_restore and block all signals for thread A 
    - acquire trap_path_lock

- Thread B: 
    - store thread B's sigmask in trap_path_sig_restore and block all signals for thread B. Thread A's original signal mask is lost. 
    - wait on acquiring trap_path_lock

- Thread A: 
    - "restore" thread A's sigmask using trap_path_sig_restore, which now contains thread B's sigmask, thus clobbering thread A's original sigmask with that of thread B.