### PR TITLE
Create a new UeventSender.sender object for every uevent call

### DIFF
--- a/src/umockdev.vala
+++ b/src/umockdev.vala
@@ -825,11 +825,10 @@ public class Testbed: GLib.Object {
      */
     public void uevent (string devpath, string action)
     {
-        if (this.ev_sender == null) {
-            debug("umockdev_testbed_uevent: lazily initializing uevent_sender");
-            this.ev_sender = new UeventSender.sender(this.root_dir);
-            assert(this.ev_sender != null);
-        }
+        UeventSender.sender ev_sender = null;
+        ev_sender = new UeventSender.sender(this.root_dir);
+        assert(ev_sender != null);
+
         debug("umockdev_testbed_uevent: sending uevent %s for device %s", action, devpath);
 
         var uevent_path = Path.build_filename(this.root_dir, devpath, "uevent");
@@ -839,7 +838,7 @@ public class Testbed: GLib.Object {
         } catch (FileError e) {
             debug("uevent: devpath %s has no uevent file: %s",  devpath, e.message);
         }
-        this.ev_sender.send(devpath, action, properties);
+        ev_sender.send(devpath, action, properties);
     }
 
     /**
@@ -1660,7 +1659,6 @@ public class Testbed: GLib.Object {
     private Regex re_record_val;
     private Regex re_record_keyval;
     private Regex re_record_optval;
-    private UeventSender.sender? ev_sender = null;
     private HashTable<string,int> dev_fd;
     private HashTable<string,ScriptRunner> dev_script_runner;
     private SocketServer socket_server = null;


### PR DESCRIPTION
The UeventSender.sender class uses libudev under the covers. libudev's documentation (referenced below) states:

> Only a single specific thread may operate on a given object during its
> entire lifetime. It's safe to allocate multiple independent objects
> and use each from a specific thread in parallel. However, it's not
> safe to allocate such an object in one thread, and operate or free it
> from any other, even if locking is used to ensure these threads don't
> operate on it at the very same time.

Therefore, if a test is multi-threaded and one thread calls to add mock devices the object might be created on that thread, then later another thread might remove the mock device and attempt to use the same libudev object.

For example, this can very easily happen in a ROS python-based environment where ROS spawns a new thread for each callback.

While I don't know what the failure might look like (as I was seeing  a different crash at the time I stumbled upon this), the libudev documentation is rather concerning given how this was being used.

Reference: https://www.freedesktop.org/software/systemd/man/latest/libudev.html