### PR TITLE
tests: Hack Gentoo build

### DIFF
--- a/tests/run-gentoo
+++ b/tests/run-gentoo
@@ -21,6 +21,8 @@ $RUNC run --interactive ${OPTS:-} \
 echo 'FEATURES="\${FEATURES} binpkg-request-signature"' >> /etc/portage/make.conf
 # install build dependencies
 ACCEPT_KEYWORDS="~*" emerge dev-util/umockdev --with-test-deps --onlydeps --getbinpkg
+# HACK: for some reason not part of build deps any more
+emerge --getbinpkg dev-lang/vala
 # install git, "meson dist" dependency
 emerge --getbinpkg dev-vcs/git
 


### PR DESCRIPTION
About a month ago, vala fell out of umockdev's build dependencies. Explicitly install it.

----

@thesamesam @mattst88: Do you happen to know why [valac does not get installed any more](https://github.com/martinpitt/umockdev/actions/runs/11624155887/job/32372326306)? It used to be part of 
```
ACCEPT_KEYWORDS="~*" emerge dev-util/umockdev --with-test-deps --onlydeps --getbinpkg
```
in the [run-gentoo test script](https://github.com/martinpitt/umockdev/blob/main/tests/run-gentoo#L23), but that doesn't happen any more. This was introduced by @mattst88 in ed29c0107ead81c1e460fff3884 and basically unchanged since then, other than the binary package optimization in commit 6a1d57a80a511c.

I can hack around it like in this PR by installing it explicitly, but that feels bad -- vala very much needs to be a build dependency of umockdev. Is that invocation wrong? Any help appreciated, thanks!