### PR TITLE
tests: Disable spidev on big-endian 32-bit platforms

### DIFF
--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -682,6 +682,12 @@ t_usbfs_ioctl_pcap ()
 void
 t_spidev_ioctl ()
 {
+  // does not work on 32 bit big-endian (such as Debian hppa)
+  if (sizeof(long) != sizeof(int64) && BYTE_ORDER == ByteOrder.BIG_ENDIAN) {
+      stdout.printf ("[SKIP: SPI emulation does not work on 32 bit big-endian] ");
+      return;
+  }
+
   var tb = new UMockdev.Testbed ();
 
   string device;


### PR DESCRIPTION
The class IoctlSpiBase (see src/umockdev-spi.vala) has a comment that it only works on 64bit platforms.
Disable those tests on 32-bit platforms for now.

This fixes my tests on the (32-bit) hppa platform.

This patch is just to show the problem (and a possible workaround).
If you find another way to fix (or skip) this test I'm fine with that,

Thanks!
Helge