### PR TITLE
Fix umockdev-vala testcase when Posix.open ("/dev/tty") succeeds

### DIFF
--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -281,8 +281,8 @@ E: SUBSYSTEM=usb
   // unknown ioctls do work on non-emulated devices
   int fd2 = Posix.open ("/dev/tty", Posix.O_RDWR, 0);
   if (fd2 > 0) {
-      assert_cmpint (Posix.ioctl (fd2, Ioctl.TIOCSBRK, 0), CompareOperator.EQ, 0);
-      assert_cmpint (Posix.errno, CompareOperator.EQ, 0);
+      assert_cmpint (Posix.ioctl (fd2, Ioctl.TIOCSBRK, 0), CompareOperator.EQ, -1);
+      assert_cmpint (Posix.errno, CompareOperator.EQ, Posix.ENOTTY);
       Posix.close (fd2);
   }
 


### PR DESCRIPTION
(this is a followup from pull request #261)
The umockdev-vala testcase still fails when called manually like this: ERROR:../tests/test-umockdev-vala.vala:284:t_usbfs_ioctl_static: assertion failed (ioctl (fd2, TIOCSBRK, 0) == 0): (-1 == 0) not ok /umockdev-testbed-vala/usbfs_ioctl_static - ERROR:../tests/test-umockdev-vala.vala:284:t_usbfs_ioctl_static: assertion failed (ioctl (fd2, TIOCSBRK, 0) == 0): (-1 == 0) Bail out!

I tested this on hppa, s390x and powerpc machines. Here is how to reproduce:

Run "meson compile"
Run "meson test"

All 7 testcases will succeed. Seems there is no problem, but please continue now:

You see the logfile mentioned like this:
Full log written to /home/deller/build/umockdev/build/meson-logs/testlog.txt

Open that "testlog.txt" file and search for the
"umockdev:fails-valgrind / umockdev-vala" test, e.g.:

test:         umockdev:fails-valgrind / umockdev-vala
command:      UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MALLOC_CHECK_=3 TOP_SRCDIR=/home/deller/build/umockdev G_DEBUG=fatal-warnings,fatal-criticals,gc-friendly ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 MALLOC_PERTURB_=131 MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MESON_TEST_ITERATION=1 PATH=/home/deller/build/umockdev/build:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games LD_LIBRARY_PATH=/home/deller/build/umockdev/build/:/home/deller/build/umockdev/build GI_TYPELIB_PATH=/home/deller/build/umockdev/build /home/deller/build/umockdev/src/umockdev-wrapper /home/deller/build/umockdev/build/test-umockdev-vala

Execute that "command" manually.
You will see that error on s390x and powerpc too, although the testcase succeeded above while running "meson test".

Sometimes, when called manually, the open("/dev/tty") succeeds, when called from "meson" it often fails and thus does not run the checks. In any case, the patch fixes the issue.