### PR TITLE
preload: Only emulate ioctls on emulated devices

### DIFF
--- a/src/ioctl.vapi
+++ b/src/ioctl.vapi
@@ -25,7 +25,7 @@ namespace Ioctl {
     [CCode (cheader_filename = "sys/ioctl.h")]
     public const int USBDEVFS_RESETEP;
     [CCode (cheader_filename = "sys/ioctl.h")]
-    public const int TIOCSBRK;
+    public const int FIONREAD;
 
     [CCode (cheader_filename = "linux/usbdevice_fs.h")]
     public const int USBDEVFS_CAP_ZERO_PACKET;
@@ -144,4 +144,3 @@ namespace Ioctl {
     uint8 data[0];
   }
 }
-

--- a/src/libumockdev-preload.c
+++ b/src/libumockdev-preload.c
@@ -528,6 +528,7 @@ ioctl_emulate_open(int fd, const char *dev_path, int must_exist)
 	is_default = 1;
     }
 
+    int orig_errno = errno;
     sock = _socket(AF_UNIX, SOCK_STREAM, 0);
     if (sock == -1) {
 	if (must_exist) {
@@ -535,6 +536,7 @@ ioctl_emulate_open(int fd, const char *dev_path, int must_exist)
 		    dev_path);
 	    exit(1);
 	} else {
+	    errno = orig_errno;
 	    return;
 	}
     }
@@ -546,6 +548,7 @@ ioctl_emulate_open(int fd, const char *dev_path, int must_exist)
 		    dev_path);
 	    exit(1);
 	} else {
+	    errno = orig_errno;
 	    return;
 	}
     }
@@ -558,6 +561,7 @@ ioctl_emulate_open(int fd, const char *dev_path, int must_exist)
 
     fd_map_add(&ioctl_wrapped_fds, fd, fdinfo);
     DBG(DBG_IOCTL, "ioctl_emulate_open fd %i (%s): connected ioctl sockert\n", fd, dev_path);
+    errno = orig_errno;
 }
 
 static void

--- a/src/valgrind.supp
+++ b/src/valgrind.supp
@@ -9,3 +9,15 @@
    fun:_dl_relocate_object
    ...
 }
+# ioctl emulation reads the client memory unconditionally; even for a read() call, as that is simpler overall
+{
+   remote_emulate_send_uninited
+   Memcheck:Param
+   socketcall.sendto(msg)
+   ...
+   fun:__libc_send
+   fun:send
+   fun:remote_emulate
+   fun:read
+   ...
+}

--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -269,23 +269,22 @@ E: SUBSYSTEM=usb
   /* no ioctl tree loaded */
   var ci = Ioctl.usbdevfs_connectinfo();
   assert_cmpint (Posix.ioctl (fd, Ioctl.USBDEVFS_CONNECTINFO, ref ci), CompareOperator.EQ, -1);
-  // usually ENOTTY, but seem to be EINVAL
-  assert_cmpint (Posix.errno, CompareOperator.GE, 22);
+  assert_cmpint (Posix.errno, CompareOperator.GE, Posix.EINVAL);
   Posix.errno = 0;
 
   // unknown ioctls don't work on an emulated device
-  assert_cmpint (Posix.ioctl (fd, Ioctl.TIOCSBRK, 0), CompareOperator.EQ, -1);
+  int argp;
+  assert_cmpint (Posix.ioctl (fd, Ioctl.FIONREAD, &argp), CompareOperator.EQ, -1);
   assert_cmpint (Posix.errno, CompareOperator.EQ, Posix.ENOTTY);
+  Posix.close (fd);
   Posix.errno = 0;
 
   // unknown ioctls do work on non-emulated devices
-  int fd2 = Posix.open ("/dev/tty", Posix.O_RDWR, 0);
-  if (fd2 > 0) {
-      assert_cmpint (Posix.ioctl (fd2, Ioctl.TIOCSBRK, 0), CompareOperator.EQ, 0);
-      assert_cmpint (Posix.errno, CompareOperator.EQ, 0);
-      Posix.close (fd2);
-  }
-
+  fd = Posix.open ("/dev/stdout", Posix.O_WRONLY, 0);
+  assert_cmpint (fd, CompareOperator.GE, 0);
+  assert_cmpint (Posix.errno, CompareOperator.EQ, 0);
+  assert_cmpint (Posix.ioctl (fd, Ioctl.FIONREAD, out argp), CompareOperator.EQ, 0);
+  assert_cmpint (Posix.errno, CompareOperator.EQ, 0);
   Posix.close (fd);
 }
 


### PR DESCRIPTION
Don't invoke the remote ioctl handler for host devices. This fixes e.g.
ioctls on /dev/tty or other standard devices which the tested program
may want to do.

This bug was hidden by the conditional check in t_usbfs_ioctl_static()
which skipped the check if /dev/tty wasn't accessible -- which is the
case in `meson test`. Move to a FIONREAD ioctl on /dev/stdout, which
works on ttys and pipes, i.e. everywhere. Make that check unconditional.
