### PR TITLE
packit: Re-enable CentOS 10 integration tests

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -58,8 +58,7 @@ jobs:
     packages: [umockdev-centos]
     targets:
       - centos-stream-9-x86_64
-        # blocked: https://issues.redhat.com/browse/TFT-2612
-        # - centos-stream-10-x86_64
+      - centos-stream-10-x86_64
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
https://issues.redhat.com/browse/TFT-2612 got fixed long ago.