### PR TITLE
tests: Fix ioctl data type

### DIFF
--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -1140,10 +1140,11 @@ E: SUBSYSTEM=test
   int fd = Posix.open ("/dev/test", Posix.O_RDWR, 0);
   assert_cmpint (fd, CompareOperator.GE, 0);
 
-  assert_cmpint (Posix.ioctl (fd, 1, 0xdeadbeef), CompareOperator.EQ, (int) 0xdeadbeef);
+  int value = (int) 0xdeadbeef;
+  assert_cmpint (Posix.ioctl (fd, 1, value), CompareOperator.EQ, value);
   assert_cmpint (Posix.errno, CompareOperator.EQ, 0);
 
-  assert_cmpint (Posix.ioctl (fd, 2, 0xdeadbeef), CompareOperator.EQ, -1);
+  assert_cmpint (Posix.ioctl (fd, 2, value), CompareOperator.EQ, -1);
   assert_cmpint (Posix.errno, CompareOperator.EQ, Posix.ENOMEM);
 
   assert_cmpint (Posix.ioctl (fd, 3, &ioctl_target), CompareOperator.EQ, 0);


### PR DESCRIPTION
The `0xdeadbeef` constant in Vala is implicitly an int64. On 32 bit big-endian architectures like powerpc this argument vanishes during its interpretation through varargs and long (i.e. gets shifted to the second argument, which we never look at). Explicitly make it an int.

---

This fixes the [Debian powerpc build failure](https://buildd.debian.org/status/fetch.php?pkg=umockdev&arch=powerpc&ver=0.19.1-2&stamp=1736005171&raw=0).

@hdeller FYI, as you were looking into FTBFS on other architectures. This is the last one, I debugged/validated this on `perotto` (Debian porter box).