### PR TITLE
tests: Don't assume a fixed baud rate when identifying ttys

### DIFF
--- a/tests/test-umockdev-vala.vala
+++ b/tests/test-umockdev-vala.vala
@@ -866,7 +866,8 @@ A: dev=188:1
   }
   assert_cmpstr (perr, CompareOperator.EQ, "");
   assert_cmpint (pexit, CompareOperator.EQ, 0);
-  assert (pout.contains ("speed 38400 baud"));
+  assert (pout.contains ("speed"));
+  assert (pout.contains ("baud"));
 }
 
 void


### PR DESCRIPTION
For some reason it's now 15 instead of 38400 on Ubuntu ppc64 systems. That's probably an Ubuntu bug, but it's also a bug in the test for assuming any specific speed.

Related: https://bugs.launchpad.net/bugs/2146427
Related: https://bugs.launchpad.net/bugs/2144723