### PR TITLE
ioctl: Replace array.resize(0) with empty array assignment

### DIFF
--- a/src/umockdev-ioctl.vala
+++ b/src/umockdev-ioctl.vala
@@ -189,8 +189,8 @@ public class IoctlData : GLib.Object {
     public bool reload() throws IOError {
         load_data();
 
-        children.resize(0);
-        children_offset.resize(0);
+        children = {};
+        children_offset = {};
 
         return true;
     }


### PR DESCRIPTION
Fedora rawhide's update from GCC 15 to gcc-16.1.1-2.fc45 broke the `-D_FORTIFY_SOURCE=3` build of the Vala-generated code for IoctlData.reload():

>  In function 'memset',
>      inlined from 'umockdev_ioctl_data_reload' at ../../source/src/umockdev-ioctl.vala:192:44:
>  /usr/include/bits/string_fortified.h:59:10: error: '__builtin___memset_chk' writing between 8 and 17179869176 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]

valac translates `children.resize(0)` into

```c
  self->priv->children = g_renew (UMockdevIoctlData*, self->priv->children, 0);
  (_tmp2_ > self->priv->children_length1) ? memset (self->priv->children + self->priv->children_length1, 0, sizeof (UMockdevIoctlData*) * (_tmp2_ - self->priv->children_length1)) : NULL;
```

The memset only zero-fills newly grown elements and is dynamically dead when shrinking to 0, but GCC 16's fortify analysis models g_realloc(ptr, 0) as a 0-byte object and considers the hypothetical path where the signed length is negative, making the memset size range up to 2^31 elements.

Replace it with `children = {};`. This is behaviorally equivalent for the array pointer: g_realloc(ptr, 0) already frees the buffer and returns NULL, so `resize(0)` never preserved the old allocation either. The one real difference fixes a memory leak: resize() just reallocs the buffer without unreffing the contained elements, leaking one reference per resolved child on every `reload()`, while the empty array assignment generates `_vala_array_free()` with `g_object_unref` on each element.

----

Fixes the [rawhide build failure](https://github.com/martinpitt/umockdev/actions/runs/27002917318/job/79687402814) that started happening recently.